### PR TITLE
SLING-9824 - sun.misc.Unsafe accessible in Sling Starter 12

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/MiscUnsafeTest.java
+++ b/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/MiscUnsafeTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.launchpad.webapp.integrationtest;
+
+import java.io.IOException;
+
+import org.apache.sling.commons.testing.integration.HttpTestBase;
+
+/**
+ * The <tt>MiscUnsafeTest</tt> verifies that the <tt>sun.misc.Unsafe</tt> class can be loaded
+ * 
+ */
+public class MiscUnsafeTest extends HttpTestBase {
+
+
+    public void testSunMiscUnsafeIsLoaded() throws IOException {
+
+        String content = getContent(HTTP_BASE_URL + "/bin/miscUnsafe.txt", CONTENT_TYPE_PLAIN);
+
+        assertTrue("Response did not start with sun.misc:\n" + content, content.startsWith("sun.misc"));
+    }
+
+}


### PR DESCRIPTION
Run a test verifying that the sun.misc package is accessible