### PR TITLE
SLING-10761 fix failing tests

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/VersionInfoServletTest.java
+++ b/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/VersionInfoServletTest.java
@@ -91,7 +91,7 @@ public class VersionInfoServletTest extends HttpTestBase {
 
     private void createConfiguration(final String selector) throws IOException {
         Map<String, String> properties = new HashMap<String, String>();
-        properties.put("apply", "true");
+        properties.put("apply", "update"); // NOTE: behavior changed by FELIX-6436
         properties.put("sling.servlet.selectors", selector);
         properties.put("propertylist", "sling.servlet.selectors");
         assertEquals(302, testClient.post(CONFIG_SERVLET, properties));

--- a/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/servlets/resolution/HtmlDefaultServletTest.java
+++ b/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/servlets/resolution/HtmlDefaultServletTest.java
@@ -34,8 +34,8 @@ public class HtmlDefaultServletTest extends ResolutionTestBase {
         
         // enable the HtmlDefaultServlet before testing
         Map<String, String> properties = new HashMap<String, String>();
-        properties.put("apply", "true");
-        properties.put("GET", "sling.servlet.methods");
+        properties.put("apply", "update"); // NOTE: behavior changed by FELIX-6436
+        properties.put("sling.servlet.methods", "GET");
         properties.put("propertylist", "sling.servlet.methods");
         assertEquals(302, testClient.post(CONFIG_SERVLET, properties));
     }


### PR DESCRIPTION
Tests fail if the starter includes org.apache.felix.webconsole version
4.6.4