### PR TITLE
SLING-11836 - Add Jakarta JSON support to the Sling Starter

### DIFF
--- a/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/jakarta/JsonTest.java
+++ b/src/main/java/org/apache/sling/launchpad/webapp/integrationtest/jakarta/JsonTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.launchpad.webapp.integrationtest.jakarta;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+
+import org.apache.sling.commons.testing.integration.HttpTestBase;
+
+/**
+ * Verifies that Jakarta API usage on the server is working
+ */
+public class JsonTest extends HttpTestBase {
+
+    public void testDomExecutionIsSuccessful() throws IOException {
+
+        String content = getContent(HTTP_BASE_URL + "/bin/jakarta.json", CONTENT_TYPE_JSON);
+
+        assertThat("JSON outtput", content, startsWith("{\"greeting"));
+    }
+}


### PR DESCRIPTION
Add a test that uses the Jakarta JSON test service