### PR TITLE
chore: don't generate javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
     <launchpad.readiness.mediatype>.txt:text/plain</launchpad.readiness.mediatype>
 
     <jackrabbit.version>2.16.3</jackrabbit.version>
+
+    <javadoc.excludePackageNames>org.apache.sling.*</javadoc.excludePackageNames>
   </properties>
 
   <scm>


### PR DESCRIPTION
The javadoc generation fails with multiple errors and we don't need to generate it for these tests.