### PR TITLE
SLING-13201 Enable StreamedUploadTest testStreamedUploadWithJavaxPart

### DIFF
--- a/src/main/java/org/apache/sling/starter/webapp/integrationtest/servlets/StreamedUploadTest.java
+++ b/src/main/java/org/apache/sling/starter/webapp/integrationtest/servlets/StreamedUploadTest.java
@@ -37,10 +37,6 @@ public class StreamedUploadTest extends HttpTestBase {
     private static final String STREAM_MODE = "stream";
 
     public void testStreamedUploadWithJavaxPart() throws IOException {
-        // enable once SLING-13083 is fixed
-        if (true) {
-            return;
-        }
         final String url = HTTP_BASE_URL + SERVLET_PATH;
 
         // Create a test file to upload


### PR DESCRIPTION
SLING-13083 has been fixed so the testStreamedUploadWithJavaxPart test should now be enabled