### PR TITLE
SLING-13247 allow a Content-Type response header with a charset

### DIFF
--- a/src/main/java/org/apache/sling/starter/webapp/integrationtest/servlets/HeadServletTest.java
+++ b/src/main/java/org/apache/sling/starter/webapp/integrationtest/servlets/HeadServletTest.java
@@ -88,7 +88,7 @@ public class HeadServletTest {
         final int status = H.getHttpClient().executeMethod(head);
         assertEquals(200, status);
         assertNull("Expecting null body", head.getResponseBody());
-        assertCommonHeaders(head, "text/html");
+        assertCommonHeaders(head, "^text\\/html(;\\s*charset=.*)?$");
     }
 
     @Test


### PR DESCRIPTION
Update HeadServletTest to allow a Content-Type response header with a charset

The latest versions of jetty are appending the charset to the Content-Type header of the response.

The result is the following assertion failing in the smote test.  Fix by adjusting the value matching to allow an optional charset suffix.

`HeadServletTest.htmlHead:91->assertCommonHeaders:65->assertResponseHeader:58 Expected regexp text/html for header Content-Type, header value is text/html;charset=utf-8`